### PR TITLE
Added support for entry types & other element types

### DIFF
--- a/prune/twigextensions/PruneTwigExtension.php
+++ b/prune/twigextensions/PruneTwigExtension.php
@@ -84,7 +84,15 @@ class PruneTwigExtension extends \Twig_Extension
 
 		foreach ($this->fields as $key) {
 			if (isset($item->{$key})) {
-				$new_item[$key] = $item->{$key};
+				if(is_object($item->{$key}) && method_exists($item->{$key}, 'attributeNames')) {
+					$new_item[$key] = new \stdClass();
+					foreach($item->{$key}->attributeNames() as $attribute) {
+						 $new_item[$key]->$attribute = $item->{$key}->{$attribute};
+					} 
+				}
+				else {
+					$new_item[$key] = $item->{$key};
+				}
 			}
 		}
 

--- a/prune/twigextensions/PruneTwigExtension.php
+++ b/prune/twigextensions/PruneTwigExtension.php
@@ -39,7 +39,7 @@ class PruneTwigExtension extends \Twig_Extension
     }
 
 	/**
-	 * Convert an EntryModel into an array with the specified fields
+	 * Convert a BaseModel into an array with the specified fields
 	 *
 	 * @param array  $input  The content being filtered
 	 * @param array  $fields An array of the fields to keep
@@ -61,24 +61,24 @@ class PruneTwigExtension extends \Twig_Extension
 
 		$output = array();
 
-		foreach ($input as $entry) {
-			if ( ! ($entry instanceof EntryModel)) {
+		foreach ($input as $element) {
+			if ( ! ($element instanceof BaseModel)) {
 				continue;
 			}
 
-			$output[] = $this->returnPrunedArray($entry);
+			$output[] = $this->returnPrunedArray($element);
 		}
 
 		return $output;
 	}
 
 	/**
-	 * Given an EntryModel, return an array with only requested fields
+	 * Given a BaseModel, return an array with only requested fields
 	 *
-	 * @param EntryModel $item
+	 * @param BaseModel $item
 	 * @return array
 	 */
-	protected function returnPrunedArray(EntryModel $item)
+	protected function returnPrunedArray(BaseModel $item)
 	{
 		$new_item = array();
 


### PR DESCRIPTION
This adds support for entry types, which are blank if you include the
'type' within the prune list.
Unfortunately it does not yet allow for pruning of nested data; this
could be achieved using a dot notation.

E.g. type.handle, type.name

Also by changing the EntryModel instance of restriction to BaseModel we can prune assets too.
